### PR TITLE
Update for Terminus 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Terminus Cantilever Plugin
-[![Terminus v1.x Compatible](https://img.shields.io/badge/terminus-v1.x-green.svg)](https://github.com/terminus-plugin-project/terminus-cantilever-plugin/tree/1.x)
+[![Terminus v2.x Compatible](https://img.shields.io/badge/terminus-v2.x-green.svg)](https://github.com/terminus-plugin-project/terminus-cantilever-plugin/tree/2.x)
 
 * isolate environments by framework (drupal, drupal8, wordpress)
-* isolate environments by service level (free, basic, pro, business, performance)
+* isolate environments by plan (sandbox, basic, performance small, performance medium, elite)
 * run drush and/or wp-cli commands, or really any commands at all
 * provide organized report of operations on per site basis
 
@@ -31,12 +31,12 @@ To install this plugin place it in `~/.terminus/plugins/`.
 On Mac OS/Linux:
 ```
 mkdir -p ~/.terminus/plugins
-composer create-project -d ~/.terminus/plugins terminus-plugin-project/terminus-cantilever-plugin:~1
+composer create-project -d ~/.terminus/plugins terminus-plugin-project/terminus-cantilever-plugin:~2
 ```
 
 ## Examples
 
-```terminus can --env=live --level='pro,business,performance' --frame='drupal,drupal8' --command='terminus drush [site] pml|grep redis'```
+```terminus can --env=live --plan='basic,performance small,performance medium' --frame='drupal,drupal8' --command='terminus drush [site] pml|grep redis'```
 
 ```terminus can --env=live --frame='wordpress' --command='terminus wp [site] option get home'```
 
@@ -46,5 +46,6 @@ Run `terminus can --help` for help.
 ## TODO
 
 * Add support for organization/membership tags
+* Allow interactive input for filters
 
 This plugin is provided by [Inclind](https://www.inclind.com "Inclind's Homepage")

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "extra": {
         "terminus": {
-            "compatible-version": "^1.1"
+            "compatible-version": "^2"
         }
     },
     "require-dev": {

--- a/src/CanCommand.php
+++ b/src/CanCommand.php
@@ -1,111 +1,172 @@
 <?php
 namespace Pantheon\TerminusCantilever;
 
-use Pantheon\Terminus\Commands\Site\SiteCommand;
+use Pantheon\Terminus\Collections\Sites;
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
 
-class CanCommand extends SiteCommand
+class CanCommand extends TerminusCommand implements SiteAwareInterface
 {
-	/**
-	 * Grab all sites.
-	 *
-	 * @authorize
-	 *
-	 * @command can
-	 *
-	 * @option env Choose site environment
-	 * @option level Choose site service level (free,basic,pro,business,performance)
-	 * @option frame Choose site framework (drupal,drupal8,wordpress)
-	 * @option tags Choose site tags (development,enterprise,terminated)
-	 * @option org Name of organization/membership site belongs to
-	 * @option command Add your command (use [site] for name.env, [name] for site name, and [env] for environment)
-	 *
-	 * terminus can --env=live --level='pro,business,performance' --frame='drupal,drupal8' --command='terminus drush [site] pml|grep redis'
-	 * terminus can --env=live --frame='wordpress' --command='terminus wp [site] option get home'
-	 *
-	 */
-	public function cantilever($options = ['env' => 'dev', 'level' => null, 'frame' => 'drupal', 'tags' => null, 'org' => null, 'command' => null])
-	{
-		//show initialize
-		$this->log()->notice("Cantilever initializing...");
+    use SiteAwareTrait;
 
-		//list sites
-		$sites = $this->sites->serialize();
+    /**
+     * Grab all sites.
+     *
+     * @authorize
+     *
+     * @command can
+     *
+     * @option env Choose site environment (dev,test,live,multidev)
+     * @option plan Choose site plan (sandbox,basic,performance small,performance medium,elite)
+     * @option frame Choose site framework (drupal,drupal8,wordpress)
+     * @option tags Choose site tags (development,enterprise,terminated)
+     * @option org Name of organization/membership site belongs to
+     * @option command Add your command (use [site] for name.env, [name] for site name, and [env] for environment)
+     *
+     * terminus can --env=live --plan='basic,performance small,performance medium,elite' --frame='drupal,drupal8' --command='terminus drush [site] pml|grep redis'
+     * terminus can --env=live --frame='wordpress' --command='terminus wp [site] option get home'
+     *
+     */
+    public function cantilever($options = ['env' => 'dev', 'plan' => null, 'frame' => 'drupal', 'tags' => null, 'org' => null, 'command' => null])
+    {
+        $sites_exist = false;
 
-		if (empty($sites)) {
-			$this->log()->notice('You have no sites.');
-		} else {
-			if (isset($options['env'])) {
-				echo "environment: " . $options['env']."\n";
-			}
-			if (isset($options['tags'])) {
-				echo "tags: " . $options['tags']."\n";
-			}
-			if (isset($options['org'])) {
-				echo "organization: " . $options['org']."\n";
-			}
-			if (isset($options['env']) || isset($options['tags']) || isset($options['org'])) {
-				echo "----------\n\n";
-			}
+        //show initialize
+        $this->log()->notice("Cantilever initializing...");
 
-			//site loop
-			foreach ($sites as $key => $site) {
-//            	print_r($site);
+        //list sites
+        $sites = $this->sites->serialize();
 
-				//remove non selected sites
-				if (isset($options['level'])) {
-					$level = explode(",", $options['level']);
-					if (!in_array($site['service_level'], $level, true)) {
-						unset($sites[$key]);
-					}
-				}
+        if (empty($sites)) {
+            $this->log()->notice('You have no sites.');
+            exit;
+        }
+        if (isset($options['env'])) {
+            echo "environment: " . $options['env'] . "\n";
+        } else {
+            echo "environment: dev\n";
+        }
+        if (isset($options['plan'])) {
+            echo "plan: " . $options['plan']."\n";
+        }
+        if (isset($options['frame'])) {
+            echo "framework: " . $options['frame'] . "\n";
+        } else {
+            echo "framework: drupal\n";
+        }
+        if (isset($options['tags'])) {
+            echo "tags: " . $options['tags']."\n";
+        }
+        if (isset($options['org'])) {
+            echo "organization: " . $options['org'] . "\n";
+        }
+        if (isset($options['command'])) {
+            echo "command: " . $options['command'] . "\n";
+        }
 
-				if (isset($options['frame'])) {
-					$frame = explode(",", $options['frame']);
-					if (!in_array($site['framework'], $frame, true)) {
-						unset($sites[$key]);
-					}
-				}
+        //site loop
+        foreach ($sites as $key => $site) {
 
-				if (isset($options['tags'])) {
-					$tags = explode(",", $options['tags']);
-					if (!isset($site['tags']) || (isset($site['tags']) && !in_array($site['tags'], $tags, true))) {
-						unset($sites[$key]);
-					}
-				}
+            //select available environments
+            $all_envs = [];
+            $envs = isset($options['env']) ? explode(',', $options['env']) : ['dev'];
+            if ($environments = $this->getSite($site['name'])->getEnvironments()->serialize()) {
+                foreach ($environments as $environment) {
+                    $env = $environment['id'];
+                    $all_envs[] = $env;
+                    if (!$environment['initialized'] && ($index = array_search($env, $envs)) !== false) {
+                        unset($envs[$index]);
+                    }
+                }
+            } else {
+                $envs = [];
+            }
 
-				if (isset($options['org'])) {
-					if (preg_match("/(\b" . $options['org'] . "\b)(\n|,|$)/", $site['memberships']) == false) {
-						unset($sites[$key]);
-					}
-				}
+            //remove unknown environments
+            if (isset($envs)) {
+                foreach ($envs as $env) {
+                    if (!in_array($env, $all_envs) && ($index = array_search($env, $envs)) !== false) {
+                        unset($envs[$index]);
+                    }
+                }
+            }
 
-				//run
-				if (empty($sites)) {
-					$this->log()->notice('You have no sites.');
-				} else {
-					if (isset($sites[$key])) {
-						//print site
-						echo $site['name'] . "\n";
+            //remove sites with no environments
+            if (!isset($envs)) {
+                unset($sites[$key]);
+            }
 
-						//compile command
-						if (isset($options['command'])) {
-							$command = $options['command'];
-							$command = str_replace("[site]", $site['name'] . "." . $options['env'], $command);
-							$command = str_replace("[name]", $site['name'], $command);
-							$command = str_replace("[env]", $options['env'], $command);
+            //remove non selected sites
+            if (isset($options['plan'])) {
+                $plan = explode(',', strtolower(trim($options['plan'])));
+                if (!in_array(strtolower($site['plan_name']), $plan)) {
+                    unset($sites[$key]);
+                }
+            }
 
-							echo "----------\n";
-							$output = shell_exec($command);
-							if ($output == '') {
-								$output = "** no results **\n";
-							}
+            if (isset($options['frame'])) {
+                $frame = explode(',', strtolower(trim($options['frame'])));
+                if (!in_array(strtolower($site['framework']), $frame)) {
+                    unset($sites[$key]);
+                }
+            }
 
-							//print output
-							echo $output . "\n";
-						}
-					}
-				}
-			}
-		}
-	}
+            if (isset($options['tags'])) {
+                $tags = explode(',', strtolower(trim($options['tags'])));
+                if (!isset($site['tags']) || (isset($site['tags']) && !in_array(strtolower($site['tags']), $tags))) {
+                    unset($sites[$key]);
+                }
+            }
+
+            if (isset($options['org'])) {
+                if (preg_match("/(\b" . $options['org'] . "\b)(\n|,|$)/", $site['memberships']) == false) {
+                    unset($sites[$key]);
+                }
+            }
+
+            //run
+            if (isset($sites[$key])) {
+                //compile command
+                if (isset($options['command'])) {
+                    foreach ($envs as $env) {
+                        //print site.env
+                        $site_env = $site['name'] . '.' . $env;
+                        $chars = strlen($site_env);
+                        echo str_repeat('=', $chars) . "\n";
+                        echo $site_env . "\n";
+                        echo str_repeat('=', $chars) . "\n";
+                        $command = $options['command'];
+                        $command = str_replace("[site]", $site_env, $command);
+                        $command = str_replace("[name]", $site['name'], $command);
+                        $command = str_replace("[env]", $env, $command);
+                        $output = $this->execute($command);
+                        echo $output . "\n";
+                        $sites_exist = true;
+                    }
+                }
+            }
+        }
+        if (!$sites_exist) {
+            $this->log()->notice('You have no sites that match this filter criteria.');
+        }
+    }
+
+    /**
+     * Executes the command.
+     */
+    protected function execute($cmd)
+    {
+        $process = proc_open(
+            $cmd,
+            [
+                0 => STDIN,
+                1 => STDOUT,
+                2 => STDERR,
+            ],
+            $pipes
+        );
+        proc_close($process);
+    }
 }


### PR DESCRIPTION
This update is for Terminus 2.x compatibility.  A few things were fixed from the 1.x version:

- Output is no longer duplicated for each command
- Only valid/initialized environments are processed
- Multiple environments per site are processed separately